### PR TITLE
add thread safety

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,8 +4,11 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/3dparty/
     ${Boost_INCLUDE_DIRS}
     )
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -Wall -Wextra -Werror -g -pthread -std=c++14 -Ofast")
-set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -pthread")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -Wall -Wextra -Werror -g -std=c++14")
+set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer")
+
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -Wall -Wextra -Werror -std=c++14")
+set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer")
 
 #set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror")
 
@@ -15,19 +18,39 @@ file(GLOB BENCH_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 #Run through each source
 foreach(benchSrc ${BENCH_SRCS})
 	message("test=${benchSrc}")
-        #Extract the filename without an extension (NAME_WE)
-        get_filename_component(benchName ${benchSrc} NAME_WE)
+  #Extract the filename without an extension (NAME_WE)
+  get_filename_component(benchName ${benchSrc} NAME_WE)
 
-        #Add compile target
-        add_executable(${benchName} ${benchSrc})
+  #Add compile target
+  add_executable(${benchName} ${benchSrc})
 
-        #link to Boost libraries AND your targets and dependencies
-         target_link_libraries(${benchName} ${Boost_LIBRARIES})
+  if(benchName STREQUAL "thread")
+    set(CROSS_FILTER_MULTI_THREAD "ON")
+    if(NOT CROSS_FILTER_USE_THREAD_POOL)
+      set(CROSS_FILTER_USE_THREAD_POOL "ON")
+    endif(NOT CROSS_FILTER_USE_THREAD_POOL)
+  endif(benchName STREQUAL "thread")
 
-        #I like to move testing binaries into a testBin directory
-        set_target_properties(${benchName} PROPERTIES 
-            RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/benchBin)
-#	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
-        #Finally add it to test execution - 
-        #Notice the WORKING_DIRECTORY and COMMAND
+  if(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+    target_compile_definitions(${benchName} PRIVATE CROSS_FILTER_MULTI_THREAD)
+    target_compile_options(${benchName} PRIVATE -pthread)
+    set_target_properties(${benchName} PROPERTIES LINK_FLAGS -pthread)
+
+    if(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+      target_compile_definitions(${benchName} PRIVATE CROSS_FILTER_USE_THREAD_POOL)
+
+    endif(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+
+  else(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+    target_compile_definitions(${benchName} PRIVATE CROSS_FILTER_SINGE_THREAD)
+  endif(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+
+  #link to Boost libraries AND your targets and dependencies
+  target_link_libraries(${benchName} ${Boost_LIBRARIES})
+
+  #I like to move testing binaries into a testBin directory
+  set_target_properties(${benchName} PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/benchBin)
+  #	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
+
 endforeach(benchSrc)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,8 +4,11 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/3dparty/
     ${Boost_INCLUDE_DIRS}
     )
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -Wall -Wextra -Werror -g -pthread -std=c++14 -Ofast")
-set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -pthread")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -Wall -Wextra -Werror -g -std=c++14 -Ofast")
+set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer")
+
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -Wall -Wextra -Werror -std=c++14")
+set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer")
 
 #set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror")
 
@@ -15,19 +18,39 @@ file(GLOB BENCH_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 #Run through each source
 foreach(benchSrc ${BENCH_SRCS})
 	message("test=${benchSrc}")
-        #Extract the filename without an extension (NAME_WE)
-        get_filename_component(benchName ${benchSrc} NAME_WE)
+  #Extract the filename without an extension (NAME_WE)
+  get_filename_component(benchName ${benchSrc} NAME_WE)
 
-        #Add compile target
-        add_executable(${benchName} ${benchSrc})
+  #Add compile target
+  add_executable(${benchName} ${benchSrc})
 
-        #link to Boost libraries AND your targets and dependencies
-         target_link_libraries(${benchName} ${Boost_LIBRARIES})
+  if(benchName STREQUAL "thread")
+    set(CROSS_FILTER_MULTI_THREAD "ON")
+    if(NOT CROSS_FILTER_USE_THREAD_POOL)
+      set(CROSS_FILTER_USE_THREAD_POOL "ON")
+    endif(NOT CROSS_FILTER_USE_THREAD_POOL)
+  endif(benchName STREQUAL "thread")
 
-        #I like to move testing binaries into a testBin directory
-        set_target_properties(${benchName} PROPERTIES 
-            RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/benchBin)
-#	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
-        #Finally add it to test execution - 
-        #Notice the WORKING_DIRECTORY and COMMAND
+  if(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+    target_compile_definitions(${benchName} PRIVATE CROSS_FILTER_MULTI_THREAD)
+    target_compile_options(${benchName} PRIVATE -pthread)
+    set_target_properties(${benchName} PROPERTIES LINK_FLAGS -pthread)
+
+    if(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+      target_compile_definitions(${benchName} PRIVATE CROSS_FILTER_USE_THREAD_POOL)
+
+    endif(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+
+  else(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+    target_compile_definitions(${benchName} PRIVATE CROSS_FILTER_SINGE_THREAD)
+  endif(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+
+  #link to Boost libraries AND your targets and dependencies
+  target_link_libraries(${benchName} ${Boost_LIBRARIES})
+
+  #I like to move testing binaries into a testBin directory
+  set_target_properties(${benchName} PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/benchBin)
+  #	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
+
 endforeach(benchSrc)

--- a/benchmark/benchmark1.cpp
+++ b/benchmark/benchmark1.cpp
@@ -5,6 +5,11 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/gregorian/greg_date.hpp>
 #include "crossfilter.hpp"
+// #include "spdlog/spdlog.h"
+// #include "spdlog/async.h"
+// #include "spdlog/sinks/stdout_sinks.h"
+// #include "spdlog/sinks/basic_file_sink.h"
+// #include "spdlog/sinks/daily_file_sink.h"
 
 struct Payment {
   Payment(const uint64_t & d, double a)
@@ -109,7 +114,11 @@ int main() {
   double v2[] = {0, 0, 0, 0, 0, 0, 0, .2, .5, .7, .85, .9, .8, .69, .72, .8, .78, .7, .3, 0, 0, 0, 0, 0};
   std::random_device rd;
   std::mt19937 gen(rd());
-  
+
+  //  auto logger = spdlog::daily_logger_mt<spdlog::async_factory>("console", "thread_log.txt",10,0);
+  //  logger->flush_on(spdlog::level::info);
+  //  spdlog::set_pattern("[%H:%M:%S.%f] [%t]: %v");
+
   RandomIndex randomDayOfWeek(std::begin(v1), std::end(v1));
   RandomIndex  randomHourOfDay(std::begin(v2), std::end(v2));
   auto randomDate  = randomRecentDate(randomDayOfWeek, randomHourOfDay, 13);
@@ -158,19 +167,19 @@ int main() {
                                  });
    auto hours = hour.feature_count();
 
-  std::cout << "Indexing " << firstSize << " records: " << (mtime() - then) << "ms." << std::endl;
+  std::cout << "Indexing " << firstSize << " records: " << (mtime() - then) << " ms." << std::endl;
   auto then3 = mtime();
   payments.add(secondBatch);
 
-  std::cout << "Indexing " << secondSize << " records: " << (mtime() - then3) << "ms." << std::endl;
-  std::cout << "Total indexing time: " << (mtime() - then) << "ms." << std::endl;
+  std::cout << "Indexing " << secondSize << " records: " << (mtime() - then3) << " ms." << std::endl;
+  std::cout << "Total indexing time: " << (mtime() - then) << " ms." << std::endl;
 
    std::cout << "dates.size()=" << dates.size() << std::endl;
   std::cout << "days.size()=" << days.size() << std::endl;
   std::cout << "hours.size()=" << hours.size() << std::endl;
   std::cout << "amounts.size()=" << amounts.size() << std::endl;
   then = mtime();
-    auto today = boost::posix_time::second_clock::local_time();
+  auto today = boost::posix_time::second_clock::local_time();
   int k = 0;
 
   for(int i = 0; i < 90; ++i) {
@@ -188,11 +197,12 @@ int main() {
     }
 
   }
-  std::cout << "Filtering by date: " << ((mtime() - then) / double(k)) << "ms/op." << std::endl;
+  std::cout << "Filtering by date: " << ((mtime() - then) / double(k)) << " ms/op." << std::endl;
   date.filter_all();
 
   then = mtime();
   k = 0;
+
   //  for(int l = 0; l < 100; l++) {
   for(int i = 0; i < 7; i++) {
     for(int j = i; j < 7; j++) {
@@ -208,7 +218,7 @@ int main() {
   }
   //  }
   
-  std::cout << "Filtering by day: " << ((mtime() - then) / double(k)) << "ms/op." << std::endl;
+  std::cout << "Filtering by day: " << ((mtime() - then) / double(k)) << " ms/op." << std::endl;
   day.filter_all();
 
   then = mtime();
@@ -226,7 +236,7 @@ int main() {
       date.top(40);
     }
   }
-  std::cout << "Filtering by hour: " << ((mtime() - then) / double(k)) << "ms/op." << std::endl;
+  std::cout << "Filtering by hour: " << ((mtime() - then) / double(k)) << " ms/op." << std::endl;
   hour.filter_all();
 
   then = mtime();
@@ -243,7 +253,7 @@ int main() {
       date.top(40);
     }
   }
-  std::cout << "Filtering by amount: " << ((mtime() - then) / double(k)) << "ms/op." << std::endl;
+  std::cout << "Filtering by amount: " << ((mtime() - then) / double(k)) << " ms/op." << std::endl;
   amount.filter_all();
 
   then = mtime();
@@ -252,7 +262,7 @@ int main() {
                     return i%10 == 1;
                   });
 
-  std::cout << "Removing  " << totalSize/10 << " records: " <<  (mtime() - then) << "ms." << std::endl;
+  std::cout << "Removing  " << totalSize/10 << " records: " <<  (mtime() - then) << " ms." << std::endl;
 
   std::cout << std::endl;
   std::cout << "Day of Week:" << std::endl;

--- a/benchmark/thread.cpp
+++ b/benchmark/thread.cpp
@@ -1,0 +1,477 @@
+#include <type_traits>
+#include <condition_variable>
+#include <thread>
+#include <future>
+#include <vector>
+#include <chrono>
+#include <atomic>
+#include <random>
+#include <string>
+// #include "spdlog/spdlog.h"
+// #include "spdlog/async.h"
+// #include "spdlog/sinks/stdout_sinks.h"
+// #include "spdlog/sinks/basic_file_sink.h"
+// #include "spdlog/sinks/daily_file_sink.h"
+#include "crossfilter.hpp"
+
+
+template<std::intmax_t resolution>
+std::ostream &operator<<(
+    std::ostream &stream,
+    const std::chrono::duration<
+        std::intmax_t,
+        std::ratio<std::intmax_t(1), resolution>
+    > &duration)
+{
+    const std::intmax_t ticks = duration.count();
+    stream << (ticks / resolution) << '.';
+    std::intmax_t div = resolution;
+    std::intmax_t frac = ticks;
+    for (;;) {
+        frac %= div;
+        if (frac == 0) break;
+        div /= 10;
+        stream << frac / div;
+    }
+    return stream;
+}
+
+template<typename Clock, typename Duration>
+std::ostream &operator<<(
+    std::ostream &stream,
+    const std::chrono::time_point<Clock, Duration> &timepoint)
+{
+    typename Duration::duration ago = timepoint.time_since_epoch();
+    return stream << ago;
+}
+
+struct Record {
+  Record() {}
+  // Record(Record &&) = default;
+  uint64_t timestamp;
+  float d1;
+  float d2;
+  float d3;
+  float d4;
+  std::vector<float> v1;
+  std::vector<float> v2;
+  std::vector<float> v3;
+};
+
+struct RandomLogNormal {
+  //  std::random_device rd;
+  std::mt19937 gen;
+  std::normal_distribution<> d;
+  RandomLogNormal(double mean, double stddev)
+      :gen(),d(mean,stddev) {}
+  double operator()()  {
+    return d(gen);
+  }
+};
+
+struct random_uniform_real {
+  //  std::random_device rd;
+  std::mt19937 gen;
+  std::uniform_real_distribution<float> d;
+  random_uniform_real(float min, float max)
+      :gen(),d(min,max) {}
+  float operator()()  {
+    return d(gen);
+  }
+};
+struct random_uniform_int {
+  //  std::random_device rd;
+  std::mt19937 gen;
+  std::uniform_int_distribution<int> d;
+  random_uniform_int(int min, int max)
+      :gen(),d(min,max) {}
+  int operator()()  {
+    return d(gen);
+  }
+};
+struct Result {
+  std::vector<Record> res;
+  std::size_t size;
+  explicit Result(std::size_t s):res(s),size(0) {}
+  Result():size(0) {}
+  Result(const Result & r) = default;
+  Result(Result && r) = default;
+};
+
+struct filter_t {
+  cross::filter<Record> filter;
+  std::atomic<std::size_t> filter_size;
+  filter_t():filter_size(0) {}
+};
+
+struct stat_t {
+  struct time_stat_t {
+    std::size_t min_time = std::numeric_limits<std::size_t>::max();
+    std::size_t max_time= 0;
+    std::size_t time_sum = 0;
+    std::size_t time_cnt = 0;
+    std::chrono::time_point<std::chrono::high_resolution_clock> min_timestamp;
+    std::chrono::time_point<std::chrono::high_resolution_clock> max_timestamp;
+    time_stat_t() {
+    }
+  };
+  std::map<std::string,time_stat_t> stat_map;
+  std::mutex mutex;
+  void update(const std::string & key, std::size_t time) {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto p = stat_map.find(key);
+    if(p == stat_map.end()) {
+      p = stat_map.insert(std::make_pair(key,time_stat_t())).first;
+    }
+    p->second.time_sum += time;
+    p->second.time_cnt++;
+    if(p->second.min_time > time) {
+      p->second.min_time = time;
+      p->second.min_timestamp = std::chrono::high_resolution_clock::now();
+      // spdlog::get("console")->info("stat set_min for {} =  {}", key,p->second.min_time);
+    }
+    if(p->second.max_time < time) {
+      p->second.max_time = time;
+      p->second.max_timestamp = std::chrono::high_resolution_clock::now();
+      // spdlog::get("console")->info("stat set_max for {} =  {}", key,p->second.max_time);
+    }
+  }
+  void print() {
+    std::lock_guard<std::mutex> lk(mutex);
+    // auto logger = spdlog::get(log);
+    for(auto & m : stat_map) {
+      auto tm = (m.second.time_cnt > 0) ? m.second.time_sum / m.second.time_cnt : 0;
+
+      //      logger->info("stat {} : min = {} ms, avg = {} ms, max = {} ms -- {} {}", m.first, m.second.min_time, tm, m.second.max_time, os1.str(), os2.str());
+      if(m.second.min_time == std::numeric_limits<std::size_t>::max())
+        m.second.min_time = 0;
+      std::cout << "stat " << m.first << " : min = " << m.second.min_time << " ms, avg = " << tm << " ms, max = " << m.second.max_time << std::endl;
+      m.second.time_sum = 0;
+      m.second.time_cnt = 0;
+      m.second.max_time = 0;
+      m.second.min_time = std::numeric_limits<std::size_t>::max();
+    }
+    std::cout << " -------------------------------------------------" << std::endl;
+  }
+};
+struct producer_t {
+  filter_t & filter;
+  stat_t & stat;
+  std::atomic<bool> stop;
+  uint32_t max_size = 100000000;
+  uint32_t chunk_size = 100000;
+  uint64_t time_sum = 0;
+  uint64_t time_cnt = 0;
+  uint64_t time2_sum = 0;
+  uint64_t time2_cnt = 0;
+  int min_batch_size = 1000;
+  int max_batch_size = 1000;
+  explicit producer_t(filter_t & f, stat_t & s):filter(f), stat(s), stop(false) {};
+  void run() {
+    // spdlog::get("console")->info("profucer");
+    random_uniform_real gen(1,1000);
+    random_uniform_int r1(1,24);
+    random_uniform_int r2(1,48);
+    random_uniform_int r3(1,400);
+    auto generator= [&gen,&r1,&r2,&r3,this](auto & v) {
+                      auto n1 = r1();
+                      auto n2 = r2();
+                      auto n3 = r3();
+                      std::size_t batch_size = min_batch_size;
+                      if(n1 + n2 + n3  < 200) {
+                        batch_size = max_batch_size;
+                      }
+                      auto cur = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+                      v.res.resize(batch_size);
+                      for(auto& r : v.res) {
+                        r.timestamp =cur;
+                        r.d1 = gen();
+                        r.d2 = gen();
+                        r.d3 = gen();
+                        r.d4 = gen();
+                        r.v1.resize(n1);
+                        r.v2.resize(n2);
+                        r.v3.resize(n3);
+                        std::for_each(r.v1.begin(),r.v1.end(),[&gen](auto & v) { v = gen();});
+                        std::for_each(r.v2.begin(),r.v2.end(),[&gen](auto & v) { v = gen();});
+                        std::for_each(r.v3.begin(),r.v3.end(),[&gen](auto & v) { v = gen();});
+                      }
+                      v.size = batch_size*(sizeof(Record) + (n1 + n2 + n3)*sizeof(float));
+                      return ;
+                    };
+    Result batch1;
+    Result batch2;
+    auto fill = [this](Result & b) {
+                  b.res.reserve(max_batch_size);
+                  for(auto & v : b.res) {
+                    v.v1.reserve(24);
+                    v.v2.reserve(48);
+                    v.v2.reserve(400);
+                  }
+                  b.size = 0;
+                };
+    fill(batch1);
+    fill(batch2);
+    auto feature = std::async(std::launch::async,[&batch1,&generator](){return generator(batch1);});
+    std::size_t add_size = 0;
+    // auto logger = spdlog::get("console");
+    while(!stop) {
+      // logger->info("start") ;
+      auto start = std::chrono::high_resolution_clock::now();
+      feature.get();
+      batch1.res.swap(batch2.res);
+      batch2.size = batch1.size;
+      feature =  std::async(std::launch::async,[&batch1,&generator](){return generator(batch1);});
+      auto end = std::chrono::high_resolution_clock::now();
+      stat.update("producer_generator",std::chrono::duration_cast<std::chrono::milliseconds>((end - start)).count());
+      // logger->info("prepare") ;
+      filter.filter.add(batch2.res);
+      // logger->info("added {0}",batch2.res.size()) ;
+      add_size += batch2.res.size();
+      auto fs = filter.filter_size.load();
+      filter.filter_size.store(fs + batch2.size);
+      auto end2 = std::chrono::high_resolution_clock::now();
+      stat.update("producer_add",std::chrono::duration_cast<std::chrono::milliseconds>((end2 - end)).count());
+      //      logger->info("prolog");
+    }
+  } 
+};
+struct remover_t {
+  filter_t & filter;
+  stat_t & stat;
+  std::atomic<bool> stop;
+  std::size_t max_size = 68709120;
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool notified = false;
+  explicit remover_t(filter_t & f, stat_t & s, std::size_t ms = 300000):filter(f),stat(s),stop(false),max_size(ms) {};
+  void run() {
+    filter.filter.onChange([this](cross::event event) {
+                             if(event == cross::dataAdded) {
+                               if(filter.filter_size.load() >= max_size) {
+                                 std::unique_lock<std::mutex> lock(mutex);
+                                 notified = true;
+                                 cv.notify_one();
+                               }
+                             }
+                           });
+    std::unique_lock<std::mutex> lock(mutex);
+    // auto logger = spdlog::get("console");
+    while(!stop) {
+      while(!notified) {
+        cv.wait(lock);
+      }
+      uint32_t max_time = 1000000; // start from 1 second;
+      auto cur_time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+      while(filter.filter.size() >= max_size) {
+        if(filter.filter.size() == 0) {
+          filter.filter_size = 0;
+          break;
+        }
+        std::size_t removed = 0;
+        auto t1 = std::chrono::high_resolution_clock::now();
+        // logger->info("remove prepare out");
+        filter.filter.remove([&cur_time, &removed, max_time](auto & v, int) {
+                               // remove records older than max_time
+                               if(cur_time - v.timestamp > max_time) {
+                                 removed++;
+                                 return true;
+                               }
+                               return false;
+                             });
+        // logger->info("remove {} bytes and {} records {}",removed_size, removed, max_time);
+        auto t2 = std::chrono::high_resolution_clock::now();
+        stat.update("remove",std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count());
+
+        max_time -= (max_time > 500000) ? 500000 : (max_time > 10000) ? 10000 : 1000 ; // decrease max_time for 500 milliseconds;
+      }
+      notified = false;
+    }
+  }
+};
+
+template<typename D>
+struct dim_operation_t {
+  D dim;
+  typename D::value_type_t top;
+  typename D::value_type_t bottom;
+  bool flag = false;
+  dim_operation_t(dim_operation_t && d):dim(std::move(d.dim)) {}
+  dim_operation_t(D && d):dim(std::move(d)) {}
+  void operation1() {
+    auto t = dim.top(20);
+    auto b = dim.bottom(20);
+    if(t.empty() || b.empty()) {
+      flag = true;
+      return;
+    }
+    if(t[0].d1 < b[0].d1) {
+      top  = b[0].d1;
+      bottom = t[0].d1;
+    } else {
+      top  = t[0].d1;
+      bottom = b[0].d1;
+    }
+    flag = false;
+  }
+  void operation2() {
+    if(flag)
+      return;
+    dim.filter_range(bottom,top);
+  }
+  void operation3() {
+    dim.filter_function([](auto & r) { return r > 50 ;});
+  }
+  void operation_clear() {
+    dim.filter_all();
+  }
+};
+
+template<typename G>
+struct group_operation_t {
+  G group;
+  group_operation_t(group_operation_t && g):group(std::move(g.group)) {}
+  group_operation_t(G && g):group(std::move(g)) {}
+  void operation1() {
+    group.order([](auto r) {return -r;});
+  }
+  void operation2() {
+    group.top(20,[](auto r) { return r;});
+  }
+  void operation3() {
+    group.top(20);
+  }
+  void operation_clear() {
+    group.order_natural();
+  }
+};
+template<typename Dim>
+struct consumer_t {
+  filter_t & filter;
+  stat_t & stat;
+  Dim dim;
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool notified = false;
+  std::chrono::time_point<std::chrono::high_resolution_clock> last_time;
+  std::string key;
+  consumer_t(consumer_t && v) :filter(v.filter),stat(v.stat),dim(std::move(v.dim)),notified(false),key(v.key) {};
+
+  explicit consumer_t(filter_t & f, stat_t & s, int k, Dim && dim):filter(f),stat(s), dim(std::move(dim)) {
+    key = std::to_string(k);
+  }
+  void run() {
+    last_time = std::chrono::high_resolution_clock::now();
+    // auto logger = spdlog::get("console");
+    filter.filter.onChange([this](cross::event event){
+
+                             if(event != cross::dataAdded)
+                               return;
+                             // logger->info("[{}] onChange {}",key,event);
+                             std::unique_lock<std::mutex> lock(mutex);
+                             notified = true;
+                             cv.notify_one();
+                           });
+    //    random_uniform_real gen(1,1000);
+    std::unique_lock<std::mutex> lock(mutex);
+
+    while(true) {
+      while(!notified) {
+        cv.wait(lock);
+      }
+      auto new_time1 = std::chrono::high_resolution_clock::now();
+      notified = false;
+      stat.update(key + " call_cycle",std::chrono::duration_cast<std::chrono::milliseconds>(new_time1 - last_time).count());
+      stat.update(key + " operation1",measure([this](){dim.operation1();}));
+      stat.update(key + " operation2",measure([this](){dim.operation2();}));
+      stat.update(key + " operation3",measure([this](){dim.operation3();}));
+      stat.update(key + " clear",measure([this](){dim.operation_clear();}));
+      last_time = std::chrono::high_resolution_clock::now();
+    }
+  }
+  template<typename F>
+  uint64_t measure( F && f) {
+    auto t1 = std::chrono::high_resolution_clock::now();
+    f();
+    auto t2 = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+  }
+};
+template<typename D>
+decltype(auto) make_dimension_consumer(D d, filter_t & filter, stat_t & stat, int key) {
+  auto op = dim_operation_t<decltype(d)>(std::move(d));
+  return consumer_t<decltype(op)>(filter,stat,key,std::move(op));
+}
+template<typename G>
+decltype(auto) make_group_consumer(G g, filter_t & filter, stat_t & stat, int key) {
+  auto gop = group_operation_t<decltype(g)>(std::move(g));
+  return consumer_t<decltype(gop)>(filter,stat,key,std::move(gop));
+}
+int main() {
+  //   auto logger = spdlog::stdout_logger_mt("console");
+  //  auto logger = spdlog::daily_logger_mt<spdlog::async_factory>("console", "thread_log.txt",10,0);
+  //  //  auto logger = spdlog::daily_logger_mt("console", "thread_log.txt",10,0);
+  // logger->flush_on(spdlog::level::info);
+  // //spdlog::flush_every(std::chrono::seconds(3));
+  // spdlog::set_pattern("[%H:%M:%S.%f] [%t]: %v");
+
+  filter_t filter;
+#ifdef CROSS_FILTER_USE_THREAD_POOL
+  filter.filter.set_thread_pool_size(4);
+#endif
+
+  stat_t stat;
+  producer_t p(filter,stat);
+  remover_t r(filter,stat);
+
+  std::vector<std::thread> threads;
+
+  auto cons1 = make_dimension_consumer(filter.filter.dimension([](auto v) { return v.d1;}),filter,stat,1);
+  auto cons2 = make_dimension_consumer(filter.filter.dimension([](auto v) { return v.d2;}),filter,stat,2);
+  auto cons3 = make_dimension_consumer(filter.filter.dimension([](auto v) { return v.d3;}),filter,stat,3);
+  auto cons4 = make_dimension_consumer(filter.filter.iterable_dimension([](auto v) { return v.v1;}),filter,stat,4);
+  auto cons5 = make_dimension_consumer(filter.filter.iterable_dimension([](auto v) { return v.v2;}),filter,stat,5);
+  auto cons6 = make_dimension_consumer(filter.filter.iterable_dimension([](auto v) { return v.v3;}),filter,stat,6);
+
+  auto cons7 = make_group_consumer(cons1.dim.dim.feature_count(),filter,stat,7);
+  auto cons8 = make_group_consumer(cons1.dim.dim.feature_count(),filter,stat,8);
+  auto cons9 = make_group_consumer(cons2.dim.dim.feature_all_count(),filter,stat,9);
+  auto cons10 = make_group_consumer(cons3.dim.dim.feature([](auto r)  { return (r < 100) ? 1 : 0; }),filter,stat,10);
+  auto cons11 = make_group_consumer(cons4.dim.dim.feature_count(),filter,stat,11);
+  auto cons12 = make_group_consumer(cons5.dim.dim.feature_all_count(),filter,stat,12);
+  auto cons13 = make_group_consumer(cons6.dim.dim.feature([](auto r)  { return (r < 100.0) ? 1 : 0; }),filter,stat,13);
+  auto cons14 = make_group_consumer(filter.filter.feature_count(),filter,stat,14);
+
+  std::thread t1([&r]() { r.run();});
+  std::thread t([&p]() { p.run();});
+  std::thread stat_thread([&stat]() {
+                            while(true) {
+                              stat.print();
+                              std::this_thread::sleep_for(std::chrono::seconds(10));
+                            }
+                          });
+#define START_THREAD(op)                       \
+  threads.emplace_back([&op](){op.run();});
+
+  START_THREAD(cons1);
+  START_THREAD(cons2);
+  START_THREAD(cons3);
+  START_THREAD(cons4);
+  START_THREAD(cons5);
+  START_THREAD(cons6);
+  START_THREAD(cons7);
+  START_THREAD(cons8);
+  START_THREAD(cons9);
+  START_THREAD(cons10);
+  START_THREAD(cons11);
+  START_THREAD(cons12);
+  START_THREAD(cons13);
+  START_THREAD(cons14);
+  t.join();
+  t1.join();
+  stat_thread.join();
+  for(auto & tt : threads) {
+    tt.join();
+  }
+  return 0;
+}

--- a/include/3dparty/nod.hpp
+++ b/include/3dparty/nod.hpp
@@ -10,10 +10,9 @@
 #include <thread>       // std::this_thread::yield()
 #include <type_traits>  // std::is_same
 #include <iterator>     // std::back_inserter
-
 namespace nod {
 	// implementational details
-	namespace detail {
+namespace detail {
 		/// Interface for type erasure when disconnecting slots
 		struct disconnector {
 			virtual void operator()( std::size_t index ) const = 0;
@@ -390,6 +389,16 @@ namespace nod {
 					}
 				}
 			}
+
+    template<typename Pool>
+    void emit_in_pool(Pool  pool) {
+      mutex_lock_type lock{ _mutex };
+      for( auto const& slot : _slots ) {
+        if( slot ) {
+          pool(slot);
+        }
+      }
+    }
 
 			/// Construct a accumulator proxy object for the signal.
 			///

--- a/include/detail/crossfilter.hpp
+++ b/include/detail/crossfilter.hpp
@@ -11,11 +11,13 @@ Copyright (c) 2018 Dmitry Vinokurov */
 #include <type_traits>
 #include <sstream>
 #include <cstddef>
+
 #include "detail/crossfilter_impl.hpp"
 #include "detail/dimension_impl.hpp"
 #include "detail/feature_impl.hpp"
 
 #include "detail/utils.hpp"
+#include "detail/thread_policy.hpp"
 
 namespace cross {
 
@@ -35,9 +37,21 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
   using connection_type_t = typename impl::filter_impl<T,Hash>::connection_type_t;
   template<typename F> using signal_type_t = typename impl::filter_impl<T,Hash>::template signal_type_t<F>;
 
+
   template <typename, typename, typename, bool> friend struct impl::feature_impl;
   template <typename, typename, typename, typename> friend struct impl::dimension_impl;
-
+  using reader_lock_t = cross::thread_policy::read_lock_t;
+  using writer_lock_t = cross::thread_policy::write_lock_t;
+  using impl::filter_impl<T,Hash>::mutex;
+  signal_type_t<void(cross::event)>           on_change_signal;
+ private:
+  bool empty_unlocked() const {
+    return impl_type_t::data.empty();
+  }
+  void trigger_on_change(cross::event event)  override {
+    on_change_signal(event);
+  }
+ public:
   struct iterator {
     using iterator_category = std::input_iterator_tag;
     using value_type = T;
@@ -49,6 +63,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
     std::vector<T> & data;
     iterator(std::size_t i, std::vector<T> & d):index(i),data(d) {}
     friend struct filter;
+
    public:
 
     iterator(const iterator & i):index(i.index),data(i.data) {}
@@ -164,7 +179,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
   /**
      Create crossfilter with empty data
    */
-  filter() {}
+  filter() = default;
 
   /**
      Create crossfilter and add data from 'data'
@@ -175,7 +190,15 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
       :impl_type_t(std::begin(data), std::end(data)) {}
 
 
-
+  #ifdef CROSS_FILTER_USE_THREAD_POOL
+  /**
+     set size of internal thread pool
+     \param[in] thread_num - amount of threads in thread pool
+  */
+  void set_thread_pool_size(uint32_t thread_num ) {
+    impl_type_t::set_thread_pool_size(thread_num);
+  }
+  #endif
   /**
      Add all data from container to crossfilter
      \param[in] new_data Container of elements with type T, must support std::begin/end concept
@@ -199,6 +222,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
      Returns all of the raw records in the crossfilter, independent of any filters
    */
   std::vector<T> all() const {
+    reader_lock_t lk(mutex);
     return impl_type_t::all();
   }
 
@@ -208,6 +232,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
    */
   template<typename ...Ts>
   std::vector<T> all_filtered(Ts&... dimensions) const {
+    reader_lock_t lk(mutex);
     return impl_type_t::all_filtered(dimensions...);
   }
 
@@ -217,6 +242,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
    */
   template<typename ...Ts>
   bool is_element_filtered(std::size_t index, Ts&... dimensions) const {
+    reader_lock_t lk(mutex);
     return impl_type_t::is_element_filtered(index,dimensions...);
   }
 
@@ -225,6 +251,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
    */
   template<typename F>
   auto dimension(F getter) -> cross::dimension<decltype(getter(std::declval<record_type_t>())), T, cross::non_iterable, Hash> {
+    //    writer_lock_t lk(mutex);
     return impl_type_t::dimension(getter);
   }
 
@@ -234,6 +261,7 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
   */
   template<typename F>
   auto iterable_dimension(F getter) ->cross::dimension<decltype(getter(std::declval<record_type_t>())), T, cross::iterable, Hash> {
+    writer_lock_t lk(mutex);
     using value_type = decltype(getter(record_type_t()));
     return impl_type_t::template iterable_dimension<value_type>(getter);
   }
@@ -286,29 +314,36 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
      * dataRemoved
      * filtered
    */
-  connection_type_t onChange(std::function<void(const std::string &)> callback) {
-    return impl_type_t::on_change(callback);
+  connection_type_t onChange(std::function<void(cross::event)> callback) {
+    return on_change_signal.connect(callback);
   }
 
   void assign(std::size_t n, const T & val, bool allow_duplicate = true) {
-    if(!empty()) {
-      clear();
+    {
+      writer_lock_t lk(mutex);
+      if(!this->empty_unlocked()) {
+        impl_type_t::clear();
+      }
+      if(!allow_duplicate) {
+        impl_type_t::add(impl_type_t::size(),val, allow_duplicate);
+      } else {
+        for(std::size_t i = 0; i < n; i++)
+          impl_type_t::add(impl_type_t::size(),val, allow_duplicate);
+      }
     }
-    
-    if(!allow_duplicate) {
-      add(val,allow_duplicate);
-      return;
-    }
-    for(std::size_t i = 0; i < n; i++)
-      add(val,allow_duplicate);
+    on_change_signal(cross::dataAdded);
   }
 
   template<typename InputIterator>
   void assign(InputIterator first, InputIterator last, bool allow_duplicate = true) {
-    if(!empty()) {
-      clear();
+    {
+      writer_lock_t lk(mutex);
+      if(!empty_unlocked()) {
+        impl_type_t::clear();
+      }
+      impl_type_t::add(0,first,last,allow_duplicate);
     }
-    impl_type_t::add(0,first,last,allow_duplicate);
+    on_change_signal(cross::dataAdded);
   }
 
   void assign(std::initializer_list<T>  l, bool allow_duplicate = true) {
@@ -316,7 +351,8 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
   }
 
   const T & at(std::size_t n) const {
-    if(n > size()-1) {
+    reader_lock_t lk(mutex);
+    if(n > impl_type_t::size()-1) {
       std::ostringstream os;
       os << "n (which is " << n << ") >= " << size() << " (which is " << size() << ")";
       throw std::out_of_range(os.str());
@@ -324,13 +360,14 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
     return impl_type_t::get_raw(n);
   }
   const T & back() const noexcept {
+    reader_lock_t lk(mutex);
     return impl_type_t::data.back();
   }
   iterator begin() noexcept {
     return  iterator(0,impl_type_t::data);
   }
   iterator end() noexcept {
-    return  iterator(size(),impl_type_t::data);
+    return  iterator(impl_type_t::size(),impl_type_t::data);
   }
   iterator cbegin() const noexcept {
     return  iterator(0,impl_type_t::data);
@@ -339,8 +376,9 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
     return  iterator(size(),impl_type_t::data);
   }
   void clear() {
-    //remove([](const auto&, int ) {return true;});
+    writer_lock_t lk(mutex);
     impl_type_t::clear();
+
   }
   reverse_iterator crbegin() const noexcept {
     return reverse_iterator(end());
@@ -355,85 +393,74 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
     return reverse_iterator(begin());
   };
   bool empty() const noexcept {
+    reader_lock_t lk(mutex);
     return size() == 0;
   }
   iterator erase(iterator position) {
-    std::size_t dist = std::distance(begin(),position);
+    std::size_t dist = 0;
+    mutex.lock();
+    dist = std::distance(begin(),position);
     impl_type_t::remove(position.index, position.index+1);
     auto p = begin();
     std::advance(p,dist);
+    mutex.unlock();
+    on_change_signal(cross::dataRemoved);
     return p;
   }
   iterator erase( iterator first, iterator last) {
-     std::size_t dist2 = std::distance(begin(),last);
-     impl_type_t::remove(first.index,last.index);
+    //writer_lock_t lk(mutex);
+    mutex.lock();
+    std::size_t dist = std::distance(begin(),last);
+    impl_type_t::remove(first.index,last.index);
     auto p = begin();
-    std::advance(p,dist2);
+    std::advance(p,dist);
+    mutex.unlock();
+    on_change_signal(cross::dataRemoved);
     return p;
   }
   const T& front() const noexcept {
+    reader_lock_t lk(mutex);
     return impl_type_t::data.front();
   }
   iterator insert( iterator pos, const T & x, bool allow_duplicates = true) {
-    if(pos == end()) {
-      add(x,allow_duplicates);
-      return iterator(pos.index,impl_type_t::data);
+    {
+      writer_lock_t lk(mutex);
+      impl_type_t::add(pos.index,x, allow_duplicates);
     }
-    impl_type_t::add(pos.index,x, allow_duplicates);
+    on_change_signal(cross::dataAdded);
     return iterator(pos.index,impl_type_t::data);
   }
-  // iterator insert( iterator pos, T && x, bool allow_duplicates = true) {
-  //   if(pos == end()) {
-  //     add(x,allow_duplicates);
-  //     return iterator(pos.index,impl_type_t::data);
-  //   }
-  //   impl_type_t::add(pos.index,x, allow_duplicates);
-  //   // std::vector<T> tmp(impl_type_t::data.begin() + pos.index, impl_type_t::data.end());
-  //   // tmp.insert(tmp.begin(),x);
-  //   // impl_type_t::remove(pos.index, size());
-  //   // add(tmp, allow_duplicates);
-  //   return iterator(pos.index,impl_type_t::data);
-  // }
 
   iterator insert( iterator pos, std::initializer_list<T> l, bool allow_duplicates = true) {
-    if(pos == end()) {
-      add(l.begin(),l.end(), allow_duplicates);
-      return iterator(pos.index,impl_type_t::data);
+    {
+      writer_lock_t lk(mutex);
+      impl_type_t::add(pos.index,l.begin(),l.end(), allow_duplicates);
     }
-    impl_type_t::add(pos.index,l.begin(),l.end(), allow_duplicates);
-    // std::vector<T> tmp(impl_type_t::data.begin() + pos.index, impl_type_t::data.end());
-    // tmp.insert(tmp.begin(),l);
-    // impl_type_t::remove(pos.index, size());
-    // add(tmp,allow_duplicates);
+    on_change_signal(cross::dataAdded);
     return iterator(pos.index,impl_type_t::data);
   }
   iterator insert( iterator pos, std::size_t n, const T & x, bool allow_duplicates = true) {
-    if(pos == end()) {
-      std::vector<T> tmp(n,x);
-      add(tmp,allow_duplicates);
-      return iterator(pos.index,impl_type_t::data);
+    {
+      writer_lock_t lk(mutex);
+      if(pos == end()) {
+        std::vector<T> tmp(n,x);
+        impl_type_t::add(tmp,allow_duplicates);
+      } else {
+        std::vector<T> tmp(impl_type_t::data.begin() + pos.index, impl_type_t::data.end());
+        tmp.insert(tmp.begin(),n,x);
+        impl_type_t::add(pos.index,tmp.begin(),tmp.end(), allow_duplicates);
+      }
     }
-
-    std::vector<T> tmp(impl_type_t::data.begin() + pos.index, impl_type_t::data.end());
-    tmp.insert(tmp.begin(),n,x);
-    impl_type_t::add(pos.index,tmp.begin(),tmp.end(), allow_duplicates);
-    // impl_type_t::remove(pos.index, size());
-    // add(tmp,allow_duplicates);
+    on_change_signal(cross::dataAdded);
     return iterator(pos.index,impl_type_t::data);
   }
 
   template<typename InputIterator>
   iterator insert( iterator pos, InputIterator first, InputIterator last, bool allow_duplicates = true) {
-    if(pos == end()) {
-      //add(first,last);
-      impl_type_t::add(size(),first,last,allow_duplicates);
-      return iterator(pos.index,impl_type_t::data);
+    {
+      writer_lock_t lk(mutex);
+      impl_type_t::add(pos.index,first,last,allow_duplicates);
     }
-    impl_type_t::add(pos.index,first,last, allow_duplicates);
-    // std::vector<T> tmp(impl_type_t::data.begin() + pos.index, impl_type_t::data.end());
-    // tmp.insert(tmp.begin(),first,last);
-    // impl_type_t::remove(pos.index, size());
-    // add(tmp,allow_duplicates);
     return iterator(pos.index,impl_type_t::data);
   }
 
@@ -448,37 +475,47 @@ template <typename T, typename Hash = trivial_hash<T>> struct filter: private im
     assign(l.begin(), l.end());
   }
   const T& operator[] (std::size_t n) const noexcept {
+    reader_lock_t lk(mutex);
     return impl_type_t::get_raw(n);
   }
   void pop_back () noexcept {
+    writer_lock_t lk(mutex);
     std::size_t last = size()-1;
-    remove([last](const auto&, int i ) { return std::size_t(i) == last;});
+    impl_type_t::remove([last](const auto&, int i ) { return std::size_t(i) == last;});
   }
   void push_back (const T &x, bool allow_duplicates = true) {
-    add(x, allow_duplicates);
+    writer_lock_t lk(mutex);
+    impl_type_t::add(impl_type_t::data.size(),x, allow_duplicates);
   }
-  void push_back (T && x, bool allow_duplicates = true) {
-    add(x,allow_duplicates);
-  }
+  // void push_back (T && x, bool allow_duplicates = true) {
+  //   writer_lock_t lk(mutex);
+  //   impl_type_t::add(std::move(x),allow_duplicates);
+  // }
   const T * data () const noexcept {
+    reader_lock_t lk(mutex);
     return impl_type_t::data.data();
   }
 
   template<typename... _Args> iterator emplace (iterator position, _Args &&... args) {
+    writer_lock_t lk(mutex);
     auto index = impl_type_t::emplace(position.index,args...);
     return iterator(index,data);
   }
   template<typename... _Args> void emplace_back (_Args &&... args) {
-    impl_type_t::emplace(end().index, args...);
+    writer_lock_t lk(mutex);
+    impl_type_t::emplace(end().index,args...);
   }
 
   void reserve (std::size_t n) {
+    writer_lock_t lk(mutex);
     impl_type_t::data.reserve(n);
   }
   void shrink_to_fit () {
+    writer_lock_t lk(mutex);
     impl_type_t::data.shrink_to_fit();
   }
   //void swap (filter & x) noexcept;
+  
 };
 }
 #include "impl/crossfilter.ipp"

--- a/include/detail/dimension.hpp
+++ b/include/detail/dimension.hpp
@@ -10,15 +10,15 @@ Copyright (c) 2018 Dmitry Vinokurov */
 #include <functional>
 #include <utility>
 #include <tuple>
+#include <type_traits>
 #include "detail/dimension_impl.hpp"
 #include "detail/utils.hpp"
 #include "detail/feature_impl.hpp"
+#include "detail/thread_policy.hpp"
+#include "detail/crossfilter.hpp"
 
 namespace cross {
 template <typename, typename, typename, bool> struct feature;
-
-//template <typename, typename, typename, bool> struct cross::impl::feature_impl;
-
 
 template <typename V, typename T, typename I = cross::non_iterable, typename H = cross::trivial_hash<T> >
 struct  dimension : private impl::dimension_impl<V, T, I, H> {
@@ -31,10 +31,13 @@ struct  dimension : private impl::dimension_impl<V, T, I, H> {
   using data_iterator = typename impl::dimension_impl<V,T,I,H>::data_iterator;
   using connection_type_t = typename impl::dimension_impl<V,T,I,H>::connection_type_t;
   template<typename F> using signal_type_t = typename impl::dimension_impl<V,T,I,H>::template signal_type_t<F>;
+  using reader_lock_t = cross::thread_policy::read_lock_t;
+  using writer_lock_t = cross::thread_policy::write_lock_t;
+  using impl::dimension_impl<V,T,I,H>::crossfilter;
 
   template <typename A, typename B> friend struct impl::filter_impl;
   template <typename, typename, typename, bool> friend struct cross::impl::feature_impl;
-
+  
   static constexpr  bool get_is_iterable() {
     return isIterable;
   }
@@ -60,7 +63,6 @@ struct  dimension : private impl::dimension_impl<V, T, I, H> {
     impl::dimension_impl<V, T, I, H>::operator=(std::move(dim));
     return *this;
   }
-
 
   void dispose();
 

--- a/include/detail/feature.hpp
+++ b/include/detail/feature.hpp
@@ -10,10 +10,12 @@ Copyright (c) 2018 Dmitry Vinokurov */
 #include <functional>
 #include <unordered_map>
 #include <utility>
+#include <type_traits>
 //#include <boost/signals2.hpp>
 #include "detail/feature_impl.hpp"
 #include "detail/crossfilter_impl.hpp"
 #include "detail/dimension_impl.hpp"
+#include "detail/thread_policy.hpp"
 
 namespace cross {
 template <typename Key, typename Reduce, typename Dimension,
@@ -28,6 +30,9 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
   using value_type_t = typename feature_impl_t::value_type_t;
 
   using this_type_t = feature<Key, Reduce, Dimension, isGroupAll>;
+
+  using reader_lock_t = cross::thread_policy::read_lock_t;
+  using writer_lock_t = cross::thread_policy::write_lock_t;
 
  private:
 
@@ -47,13 +52,14 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
 
   feature(feature<Key, Reduce, Dimension, isGroupAll> && g):
       feature_impl_t(std::move(g)) {}
-      //      feature_impl_t<Key, Reduce, Record, isGroupAll>(std::move(g)) {}
+
 
   /**
      Returns a new array containing the top k groups,
      according to the group order of the associated reduce value. The returned array is in descending order by reduce value.
    */
   std::vector<group_type_t> top(std::size_t k) noexcept {
+    writer_lock_t lk(feature_impl_t::dimension->lock());
     return feature_impl_t::top(k);
   }
 
@@ -63,6 +69,7 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
    */
   template<typename OrderFunc>
   std::vector<group_type_t> top(std::size_t k, OrderFunc orderFunc) noexcept {
+    writer_lock_t lk(feature_impl_t::dimension->lock());
     return feature_impl_t::top(k, orderFunc);
   }
 
@@ -70,6 +77,7 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
      Returns the array of all groups, in ascending natural order by key. 
    */
   std::vector<group_type_t> &all() noexcept{
+    writer_lock_t lk(feature_impl_t::dimension->lock());
     return feature_impl_t::all();
   }
 
@@ -77,6 +85,7 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
      Equivalent to all()[0].second.
    */
   reduce_type_t value() noexcept {
+    writer_lock_t lk(feature_impl_t::dimension->lock());
     return feature_impl_t::value();
   }
 
@@ -87,6 +96,7 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
    */
   template<typename OrderFunc>
   this_type_t &   order(OrderFunc value) noexcept {
+    writer_lock_t lk(feature_impl_t::dimension->lock());
     feature_impl_t::order(value);
     return *this;
   }
@@ -95,13 +105,17 @@ struct feature: private impl::feature_impl<Key, Reduce, Dimension, isGroupAll> {
      A convenience method for using natural order for reduce values. Returns this grouping.
    */
   this_type_t & order_natural() noexcept{
+    writer_lock_t lk(feature_impl_t::dimension->lock());
     feature_impl_t::order_natural();
     return *this;
   }
   /**
      Returns the number of distinct values in the group, independent of any filters; the cardinality.
    */
-  std::size_t size() const noexcept { return feature_impl_t::size(); }
+  std::size_t size() const noexcept {
+    reader_lock_t lk(feature_impl_t::dimension->lock());
+    return feature_impl_t::size();
+  }
 
  
 };

--- a/include/detail/feature_impl.hpp
+++ b/include/detail/feature_impl.hpp
@@ -11,6 +11,7 @@ Copyright (c) 2018 Dmitry Vinokurov */
 #include <unordered_map>
 #include <utility>
 #include <type_traits>
+#include <map>
 #include "detail/heap.hpp"
 #include "detail/impl/group_index.hpp"
 #include "detail/crossfilter_impl.hpp"
@@ -131,6 +132,9 @@ struct feature_impl {
 
   std::vector<group_type_t> top(std::size_t k) noexcept;
 
+  template<typename OrderFunc>
+  std::vector<group_type_t> top(std::size_t k, OrderFunc value) noexcept;
+
   void reset_one();
 
   void reset();
@@ -143,7 +147,9 @@ struct feature_impl {
   feature_impl<Key, Reduce, Dimension, isGroupAll> &
   order(OrderFunc value) noexcept;
 
-  feature_impl<Key, Reduce, Dimension, isGroupAll> &order_natural() noexcept;
+  feature_impl<Key, Reduce, Dimension, isGroupAll> &order_natural() noexcept {
+    return order([](auto r) { return r;});
+  }
 
   std::size_t size() const noexcept { return groups.size(); }
   std::vector<group_type_t> & all2() {

--- a/include/detail/impl/feature_impl.ipp
+++ b/include/detail/impl/feature_impl.ipp
@@ -81,17 +81,16 @@ void feature_impl<Key, Reduce, Dimension, is_group_all>::update_one(std::size_t 
                                                                           const std::vector<std::size_t> &added,
                                                                           const std::vector<std::size_t> &removed,
                                                                           bool not_filter) {
+
   if ((filter_bit_index > 0 && dimension->dimension_offset == filter_offset &&
        dimension->dimension_bit_index == filter_bit_index) ||
       reset_needed)
     return;
-
   std::for_each(added.begin(), added.end(),
                 [this](auto i) {
                   if(dimension->zero_except(i))
                     groups[0].second = add_func(groups[0].second,dimension->get_raw(i),false);
                 });
-
   std::for_each(removed.begin(), removed.end(),
                 [this, filter_offset, filter_bit_index, not_filter] (auto i) {
                   if(filter_bit_index < 0) {
@@ -253,6 +252,30 @@ feature_impl<Key, Reduce, Dimension, is_group_all>::top(std::size_t k) noexcept 
   auto &t = all();
   auto top = select_func(t, 0, groups.size(), k);
   return sort_func(top, 0, top.size());
+}
+
+template <typename Key, typename Reduce, typename Dimension,
+          bool is_group_all>
+template<typename OrderFunc>
+inline
+std::vector<typename feature_impl<Key, Reduce, Dimension, is_group_all>::group_type_t>
+feature_impl<Key, Reduce, Dimension, is_group_all>::top(std::size_t k, OrderFunc value) noexcept {
+  auto &t = all();
+  using T = typename std::decay< decltype(value(std::declval<reduce_type_t>())) >::type;
+  auto select = std::bind(Heap<group_type_t, T>::select,
+                          std::placeholders::_1,
+                          std::placeholders::_2,
+                          std::placeholders::_3,
+                          std::placeholders::_4,
+                          [&value](const group_type_t& g) { return value(g.second);});
+
+  auto sort = std::bind(Heap<group_type_t, T>::sort, std::placeholders::_1,
+                        std::placeholders::_2,
+                        std::placeholders::_3,
+                        [&value](const group_type_t& g) { return value(g.second);});
+
+  auto top = select(t, 0, groups.size(), k);
+  return sort(top, 0, top.size());
 }
 
 template <typename Key, typename Reduce, typename Dimension,

--- a/include/detail/thread_policy.hpp
+++ b/include/detail/thread_policy.hpp
@@ -1,0 +1,59 @@
+/*This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Copyright (c) 2018 Dmitry Vinokurov */
+
+#ifndef THREAD_POLICY_H_GUARD
+#define THREAD_POLICY_H_GUARD
+
+#ifdef CROSS_FILTER_MULTI_THREAD
+#include <mutex>
+#include <shared_mutex>
+#include <condition_variable>
+#include <atomic>
+#endif 
+
+#if !defined CROSS_FILTER_MULTI_THREAD
+// use thread pool only if multithreading enabled
+#undef CROSS_FILTER_USE_THREAD_POOL
+#endif
+
+// #if defined CROSS_FILTER_USE_THREAD_POOL
+//   #if !defined CROSS_FILTER_THREAD_POOL_SIZE
+//      #define CROSS_FILTER_THREAD_POOL_SIZE 4
+//   #endif
+// #endif
+namespace cross {
+struct singlethread_policy {
+  struct mutex_type {
+    void lock() {};
+    void unlock() {}
+    void lock_shared() {}
+    void unlock_shared() {}
+    void upgrade_to_internal_lock() {}
+    void release_internal_lock() {}
+    void lock_internal() {}
+    void unlock_internal() {}
+  };
+  struct write_lock_t {
+    explicit write_lock_t(const mutex_type &) {}
+  };
+  struct read_lock_t {
+    explicit read_lock_t(const mutex_type &) {}
+  };
+};
+
+#ifdef CROSS_FILTER_MULTI_THREAD
+struct multithread_policy {
+  using mutex_type = std::shared_timed_mutex;
+  using write_lock_t = std::unique_lock<mutex_type>;
+  using read_lock_t = std::shared_lock<mutex_type>;
+};
+using thread_policy = multithread_policy;
+#else
+using thread_policy = singlethread_policy;
+#endif
+}
+#endif
+

--- a/include/detail/utils.hpp
+++ b/include/detail/utils.hpp
@@ -12,6 +12,11 @@
 
 namespace cross {
 
+enum event {
+  dataAdded,
+  dataRemoved,
+  dataFiltered
+};
 struct iterable {};
 struct non_iterable {};
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,8 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${Boost_INCLUDE_DIRS}
     )
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -Wall -Wextra -Werror -g -std=c++14")
-set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address -g -std=c++14")
-
-#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -Wall -Wextra -Werror -g -std=c++14 -Ofast")
+set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address -g -std=c++14 -Ofast")
 
 
 #file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*.cpp)
@@ -20,13 +18,25 @@ foreach(testSrc ${TEST_SRCS})
         #Add compile target
         add_executable(${testName} ${testSrc})
 
+        if(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+          target_compile_definitions(${testName} PUBLIC CROSS_FILTER_MULTI_THREAD)
+          target_compile_options(${testName} PRIVATE -pthread)
+          set_target_properties(${testName} PROPERTIES LINK_FLAGS -pthread)
+
+          if(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+            target_compile_definitions(${testName} PUBLIC CROSS_FILTER_USE_THREAD_POOL)
+          endif(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+
+        else(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+          target_compile_definitions(${testName} PUBLIC CROSS_FILTER_SINGE_THREAD)
+        endif(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+
         #link to Boost libraries AND your targets and dependencies
         target_link_libraries(${testName} ${Boost_LIBRARIES})
 
         #I like to move testing binaries into a testBin directory
-        set_target_properties(${testName} PROPERTIES 
-            RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
-#	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
+        set_target_properties(${testName} PROPERTIES RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
+          #	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
         #Finally add it to test execution - 
         #Notice the WORKING_DIRECTORY and COMMAND
         add_test(NAME ${testName} 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,8 +6,6 @@ include_directories(
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -Wall -Wextra -Werror -g -std=c++14")
 set (CMAKE_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address -g -std=c++14")
 
-#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror")
-
 
 #file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test/*.cpp)
 AUX_SOURCE_DIRECTORY(. TEST_SRCS)
@@ -20,13 +18,25 @@ foreach(testSrc ${TEST_SRCS})
         #Add compile target
         add_executable(${testName} ${testSrc})
 
+        if(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+          target_compile_definitions(${testName} PUBLIC CROSS_FILTER_MULTI_THREAD)
+          target_compile_options(${testName} PRIVATE -pthread)
+          set_target_properties(${testName} PROPERTIES LINK_FLAGS -pthread)
+
+          if(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+            target_compile_definitions(${testName} PUBLIC CROSS_FILTER_USE_THREAD_POOL)
+          endif(CROSS_FILTER_USE_THREAD_POOL STREQUAL "ON")
+
+        else(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+          target_compile_definitions(${testName} PUBLIC CROSS_FILTER_SINGE_THREAD)
+        endif(CROSS_FILTER_MULTI_THREAD STREQUAL "ON")
+
         #link to Boost libraries AND your targets and dependencies
         target_link_libraries(${testName} ${Boost_LIBRARIES})
 
         #I like to move testing binaries into a testBin directory
-        set_target_properties(${testName} PROPERTIES 
-            RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
-#	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
+        set_target_properties(${testName} PROPERTIES RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/testBin)
+          #	set_property(TARGET ${testName} PROPERTY CXX_STANDARD 17)
         #Finally add it to test execution - 
         #Notice the WORKING_DIRECTORY and COMMAND
         add_test(NAME ${testName} 

--- a/test/crossfilter_js_test.cpp
+++ b/test/crossfilter_js_test.cpp
@@ -1627,10 +1627,10 @@ BOOST_AUTO_TEST_SUITE_END();
 BOOST_AUTO_TEST_SUITE(on_change)
 BOOST_AUTO_TEST_CASE(sends_the_eventName_with_the_callback) {
   cross::filter<int> data;
-  std::string name;
+  cross::event name;
   data.onChange([&name](auto eventName) {name = eventName;});
   data.add(1);
-  BOOST_CHECK_EQUAL(name,std::string("dataAdded"));
+  BOOST_CHECK_EQUAL(name,cross::dataAdded);
 }
 BOOST_AUTO_TEST_CASE(callback_gets_called_when_removing_all_data) {
   Fixture data;

--- a/test/crossfilter_vector_api.cpp
+++ b/test/crossfilter_vector_api.cpp
@@ -143,7 +143,8 @@ BOOST_AUTO_TEST_CASE(back) {
   BOOST_TEST((Record2{4,5,"aba"}) == f.data.back());
   f.data.push_back(Record2{5,6,"abc"});
   BOOST_TEST((Record2{5,6,"abc"}) == f.data.back());
-  f.data.remove([&f](auto &, int i) { return std::size_t(i) == f.data.size()-1;});
+  auto s = f.data.size();
+  f.data.remove([s](auto &, int i) { return std::size_t(i) == s-1;});
   BOOST_TEST((Record2{4,5,"aba"}) == f.data.back());
 }
 


### PR DESCRIPTION
- Read and write operations are protected by a shared mutex.
- Added test : benchmark/thread.cpp. It emulates using of cross::filter in a multithreaded environment.
- Added new preprocessor defines: 
   1. CROSS_FILTER_MULTI_THREAD - enables multithreading in cross::filter, disabled by default.
   2. CROSS_FILTER_USE_THREAD_POOL - enables an internal thread pool for massive operations (disabled by default). When this variable defined, the new method cross::filter::set_thread_pool_size(uint32_t) is available. By default, internal thread pool uses 2 threads.
To build tests and benchmarks with multithreaded support use next command:
$cmake -DCROSS_FILTER_MULTI_THREAD=ON -DCROSS_FILTER_USE_THREAD_POOL=ON

